### PR TITLE
Local Development Improvements: Add an http dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bower_components
 # Editors
 .idea
 *.iml
+.vscode
 
 # OS metadata
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -17,14 +17,21 @@ npm i lamp-core
 
 Ensure your `serverAddress` is set correctly. If using the default server, it will be `api.lamp.digital`. Keep your `accessKey` (sometimes an email address) and `secretKey` (sometimes a password) private and do not share them with others.
 
+To make requests using `http`, enable dev mode before attempting to connect to a server. 
+
+**Warning:** Dev mode should only be used for local development!
+
 ```javascript
 import LAMP from 'lamp-core'
+LAMP.enableDevMode()    // optional
 await LAMP.connect({ serverAddress: '...', accessKey: '...', secretKey: '...' })
 ```
 
 ## API Endpoints
 
-All URIs are relative to the `serverAddress` (by default, `api.lamp.digital`) with the `https://` protocol.
+All URIs are relative to the `serverAddress` (by default, `api.lamp.digital`).
+
+The protocol defaults to `https` but `http` can be used with dev mode enabled.
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,13 @@ export default class LAMP {
     LAMP.Type.configuration = configuration
     LAMP.ResearcherSettings.configuration = configuration
   }
+  private static protocol = "https://"
+
+  public static enableDevMode() {
+    // Make all future server requests over http
+    // Only use this for local development
+    LAMP.protocol = "http://"
+  }
 
   public static addEventListener(event: string, callback: (any) => void) {
     _bus?.addEventListener(event, callback)
@@ -124,7 +131,7 @@ export default class LAMP {
     }
 
     LAMP.configuration = {
-      base: !!identity.serverAddress ? `https://${identity.serverAddress}` : "https://api.lamp.digital",
+      base: !!identity.serverAddress ? `${LAMP.protocol}${identity.serverAddress}` : `${LAMP.protocol}api.lamp.digital`,
       authorization: !!LAMP.Auth._auth.id ? `${LAMP.Auth._auth.id}:${LAMP.Auth._auth.password}` : undefined,
     }
   }
@@ -150,7 +157,7 @@ export default class LAMP {
       }
     ) {
       LAMP.configuration = {
-        base: !!identity.serverAddress ? `https://${identity.serverAddress}` : "https://api.lamp.digital",
+        base: !!identity.serverAddress ? `${LAMP.protocol}${identity.serverAddress}` : `${LAMP.protocol}api.lamp.digital`,
       }
 
       // Ensure there's actually a change to process.


### PR DESCRIPTION
This pr adds the ability to send server requests over `http` instead of `https`.

Including an `http` mode will make local development of the LAMP-server and LAMP-dashboard significantly easier.