### PR TITLE
ci: OIDC trusted publishing + release trigger fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,13 @@
 name: Publish
 on:
   release:
-    types: [created]
+    types: [published] # fires for direct creation AND draft-then-publish (types: [created] misses drafts)
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 3.0.1) — required for manual runs"
+        required: true
+        type: string
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,19 +22,26 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing — no npm token secret needed
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org/
-      - name: Autoincrement version
+      # OIDC trusted publishing requires npm >= 11.5.1; node 20 bundles npm 10
+      - run: npm install -g npm@latest
+      - name: Set version
         run: |
-          # from refs/tags/v1.2.3 or refs/tags/1.2.3 get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed -E 's#.*/v?##')
+          # manual runs pass an explicit version; release runs derive it from
+          # the tag (refs/tags/v1.2.3 or refs/tags/1.2.3 -> 1.2.3)
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(echo $GITHUB_REF | sed -E 's#.*/v?##')
+          fi
           npm version --no-git-tag-version $VERSION
         shell: bash
       - run: npm install
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
## Why

`lamp-core@3.0.0` failed to publish twice, for two independent reasons this PR fixes:

1. **Trigger:** `release: types: [created]` is not emitted for releases that start as drafts — the 3.0.0 release was drafted then published, so the workflow never fired.
2. **Auth:** the `NPM_AUTH_TOKEN` secret has expired (npm publish returned E404-masked auth failure). Tokens now have mandatory expiry, so this would keep recurring.

## Changes

- `types: [created]` → `types: [published]` — fires for both direct creation and draft-then-publish
- **OIDC trusted publishing**: `id-token: write` permission + npm ≥ 11.5.1 (Node 20 bundles npm 10), `NPM_AUTH_TOKEN` removed. The trusted publisher is already configured on npmjs.com for this repo/workflow, and publish access is set to 2FA-or-trusted-publisher. Publishes also gain provenance attestations.
- **`workflow_dispatch` escape hatch** with an explicit `version` input, so a stuck release can be published manually without recreating release objects

## After merge (to ship 3.0.0)

Release-event workflows run the workflow file at the tag's commit, so the existing `3.0.0` tag (which predates this fix) must be moved: delete tag + release, re-tag at the merge commit, recreate the release. Package contents are unchanged — the only delta is this workflow file.

Note: the now-unused `NPM_AUTH_TOKEN` repo secret can be deleted after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)