### PR TITLE
ci: pin npm@11 for publish (npm@12 requires node >= 22)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org/
-      # OIDC trusted publishing requires npm >= 11.5.1; node 20 bundles npm 10
-      - run: npm install -g npm@latest
+      # OIDC trusted publishing requires npm >= 11.5.1; node 20 bundles npm 10.
+      - run: npm install -g npm@11
       - name: Set version
         run: |
           # manual runs pass an explicit version; release runs derive it from


### PR DESCRIPTION
Follow-up to #107 — the publish run for 3.0.0 failed at `npm install -g npm@latest`: latest is now npm 12, which refuses Node 20 (EBADENGINE, requires ^22.22.2). Pinning npm@11, which supports Node 20 and includes OIDC trusted publishing (>= 11.5.1).

After merge, 3.0.0 can be published via the new `workflow_dispatch` path (`version: 3.0.0`) — no tag/release recreation needed this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)