### PR TITLE
ci: publish with explicit --tag latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,4 @@ jobs:
           npm version --no-git-tag-version $VERSION
         shell: bash
       - run: npm install
-      - run: npm publish
+      - run: npm publish --tag latest # explicit: old date-style versions (2025.x) are semver-higher than 3.x


### PR DESCRIPTION
Third and final follow-up for the 3.0.0 publish. OIDC auth now works (#107, #108) — the remaining failure is npm refusing to *implicitly* tag `latest` because the legacy date-style versions (`2025.11.28`) are semver-higher than `3.0.0`:

```
npm error Cannot implicitly apply the "latest" tag because previously published version 2025.11.28 is higher than the new version 3.0.0. You must specify a tag using --tag.
```

Explicit `--tag latest` is allowed and is what we want (`npm install lamp-core` should resolve to 3.x). This applies to every future 3.x release, so it belongs in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)