### PR TITLE
fix: load self identity before emitting LOGIN in finalizeLogin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -366,8 +366,8 @@ export default class LAMP {
         serverAddress: LAMP.configuration?.base,
       }
       if (LAMP.Auth._authScheme === "session") {
-        loginEventPayload.accessToken = sessionLoginResult?.mobileAuth.accessToken,
-        loginEventPayload.refreshToken = sessionLoginResult?.mobileAuth.refreshToken
+        loginEventPayload.accessToken = sessionLoginResult?.mobileAuth?.accessToken
+        loginEventPayload.refreshToken = sessionLoginResult?.mobileAuth?.refreshToken
       } else {
         loginEventPayload.authorizationToken = LAMP.configuration?.authorization
       }
@@ -433,8 +433,13 @@ export default class LAMP {
    */
   public static async finalizeLogin(oneTimeToken: string) {
     if (LAMP.Auth._authScheme === "session") {
-      const result: any = await Fetch.get(`/login/one-time-token/${oneTimeToken}`, LAMP.configuration) 
+      const result: any = await Fetch.get(`/login/one-time-token/${oneTimeToken}`, LAMP.configuration)
       if (result.mobileAuth) {
+        // On this flow the page has just loaded and _me has not been populated
+        // yet. The native mobile bridges DISCARD any LOGIN message without
+        // identityObject.id, so load self information before emitting — same
+        // as set_identity does.
+        await LAMP.Auth._load_self_information()
         LAMP.dispatchEvent("LOGIN", {
           authScheme: LAMP.Auth._authScheme,
           identityObject: LAMP.Auth._me,


### PR DESCRIPTION
## Bug

`finalizeLogin` (the one-time-token flow used by the gateway/OAuth login) emits the `LOGIN` event with `identityObject: LAMP.Auth._me` — but on that flow the page has just loaded and `_me` has not been populated yet, so the event goes out with `identityObject: undefined`.

The native mobile apps (iOS and Android) require `identityObject.id` before trusting a login message, so they silently discard the entire event — including the `mobileAuth` access/refresh tokens. **Result: a session login via the gateway/OAuth flow never arms native bearer auth on either platform.** The in-webview password path (`set_identity`) is unaffected because it already loads self information before emitting.

## Fix

Load self information before dispatching, exactly as `set_identity` does.

Also in this change:
- Proper optional chaining on `sessionLoginResult?.mobileAuth?.accessToken` — previously a session-scheme server responding without `mobileAuth` would throw after a successful login and break web login entirely.
- Replace an accidental comma operator with two statements.

## Impact / risk

- Only executes when the server advertises `authScheme: "session"` — a no-op against basic-auth servers, so zero impact on existing deployments.
- On the session path the added identity load is idempotent (the dashboard performs it moments later regardless).

## Release note

`lamp-core@3.0.0` shipped without this fix, so the gateway-flow native token bridge is broken in `3.0.0`. This should go out as `3.0.1` before mobile (Release 2) testing begins.